### PR TITLE
Adds hackster example code to library examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ html
 latex
 src/html/**
 src/latex/**
-examples/basicUsage/basicUsage.cpp
-examples/advancedUsage/advancedUsage.cpp
+examples/**/*.cpp

--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ The second example can be run by specifying the build environement `advancedUsag
 ```bash
 pio run -e advancedUsage -t upload && pio device monitor
 ```
-Available environments are `basicUsage` and `advancedUsage`. Environment `basicUsage` is default and will be used if you omit the `-e` flag.
+Available environments are `basicUsage`, `advancedUsage` and `hacksterExample`. Environment `basicUsage` is default and will be used if you omit the `-e` flag.
+Please refer to the README in `examples/hacksterExample` for more information about this environment, as it is designed to accompany an example published to [Hackster.io](https://www.hackster.io/sensirion-software/easily-read-out-sensirion-sensor-measurements-on-arduino-9c1862).
+
 In case you're using some other board, it is recommended you create a new environment in the `platformio.ini` file, using the existing environments as a template. Find your `board` parameter [here](https://docs.platformio.org/en/latest/boards/index.html).
 
 ## Dependencies

--- a/examples/hacksterExample/README.md
+++ b/examples/hacksterExample/README.md
@@ -1,0 +1,55 @@
+
+Please visit the article on Hackster.io accompanying this example script:
+https://www.hackster.io/sensirion-software/easily-read-out-sensirion-sensor-measurements-on-arduino-9c1862
+
+For more information about this library, refer to the README two levels up:
+
+```
+Sensirion UPT I2C Auto Detection
+├── examples
+│   ├── advancedUsage
+│   │   └── ...
+│   ├── basicUsage
+│   │   └── ...
+│   └── hacksterExample
+│       ├── hacksterExample.ino
+│       ├── platformio.ini
+│       └── README.md               <=== YOU ARE HERE
+├── ...
+├── README.md                       <=== THIS ONE
+└── src
+    └── ...
+```
+(Also available here: https://github.com/Sensirion/arduino-upt-i2c-auto-detection)
+
+## How to use
+Follow the wiring instructions on the Hackster article, and execute the code with the steps outlined below:
+### Arduino IDE
+Install the software from the [official website](https://www.arduino.cc/en/software) and read [this short tutorial](https://docs.arduino.cc/software/ide-v2/tutorials/getting-started-ide-v2/) to get an introduction to the IDE.
+Next, select your board and port in the Board Manager by following [these instructions](https://support.arduino.cc/hc/en-us/articles/4406856349970-Select-board-and-port-in-Arduino-IDE).
+Then, we'll need to [install all the libraries](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries/) required to run Autodetection. In the library manager, search for the _Sensirion UPT I2C Auto Detection_ library. Be sure to select to install all dependencies, lest you'll have to add the following manually:
+* [Sensirion Arduino Core](https://www.arduino.cc/reference/en/libraries/sensirion-core/)
+* [Sensirion UPT Core](https://www.arduino.cc/reference/en/libraries/sensirion-upt-core/)
+* [Sensirion I2C SCD4x](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-scd4x/)
+* [Sensirion I2C SFA3x](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-sfa3x/)
+* [Sensirion I2C SVM4x](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-svm4x/)
+* [Sensirion I2C SHT4x](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-sht4x/)
+* [Sensirion I2C SEN5x](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-sen5x/)
+* [Sensirion I2C SCD30](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-scd30/)
+* [Sensirion I2C SGP41](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-sgp41/)
+* [Sensirion I2C STC3x](https://www.arduino.cc/reference/en/libraries/sensirion-i2c-stc3x/)
+
+Then, open the example either by opening `hacksterExample.ino` in Arduino IDE or by navigating to 
+
+    File => Examples => Sensirion UPT I2C Auto Detection => hacksterExample
+
+Finally, click the Upload button (top-left of the window, labelled with an → arrow) and then open the serial monitor (Q-looking button at the top-right of the window). Be sure to select `115200 baud` in the drop-down to the right of the serial monitor.
+
+### PlatformIO
+The most straight-forward way to use [PlatformIO](https://platformio.org/platformio-ide) is as an extension to Microsoft's [Visual Studio Code](https://code.visualstudio.com/), you'll find it easily among the extensions available for it. I'll refer to the official installation instructions [here](https://platformio.org/install/ide?install=vscode).
+
+Open this folder (`hacksterExample.ino`) in the IDE and type
+```bash
+$ pio run -t upload && pio device monitor
+```
+in the command line (which you can open with `ctrl+J`). The measurements start showing in the console.

--- a/examples/hacksterExample/hacksterExample.ino
+++ b/examples/hacksterExample/hacksterExample.ino
@@ -1,0 +1,64 @@
+/*
+Example code for the hackster.io article showcasing how to use this library:
+https://www.hackster.io/sensirion-software/easily-read-out-sensirion-sensor-measurements-on-arduino-9c1862
+*/
+
+#include "Arduino.h"
+#include "Sensirion_upt_i2c_auto_detection.h"
+#include "Wire.h"
+
+I2CAutoDetector i2CAutoDetector(Wire);
+SensorManager sensorManager(i2CAutoDetector);
+
+int maxNumSensors;
+const MeasurementList **dataPointers;
+
+void setup() {
+  // 1.1 Initialize serial port at 115200 baud
+  Serial.begin(115200);
+
+  // 1.2 Initialize the I2C bus on pins 21 (SDA) and 22 (SCL)
+  int sda_pin = 21;
+  int scl_pin = 22;
+  Wire.begin(sda_pin, scl_pin);
+
+  // 1.3 Build the "reverse PO Box" we'll use to retrieve sensor data
+  maxNumSensors = sensorManager.getMaxNumberOfSensors();
+  dataPointers = new const MeasurementList *[maxNumSensors] { nullptr };
+};
+
+void loop() {
+  // 2.1 Task SensorManager to fetch sensor data
+  sensorManager.refreshAndGetSensorReadings(dataPointers);
+
+  // 2.2 Peek into the non-empty mailboxes and show their contents
+  for (int i = 0; i < maxNumSensors; i++) {
+    if (dataPointers[i] != nullptr) {
+      const MeasurementList measurementList = *dataPointers[i];
+      for (int m = 0; m < measurementList.getLength(); m++) {
+        const Measurement measurement = measurementList.getMeasurement(m);
+        if (m == 0) {
+          Serial.print("Showing measurements for sensor ");
+          Serial.println(
+              sensorLabel(measurement.metaData.deviceType.sensorType));
+        }
+
+        Serial.print("Measured ");
+        Serial.print(quantityOf(measurement.signalType));
+        Serial.print(": ");
+        Serial.print(measurement.dataPoint.value);
+        Serial.print(" ");
+        Serial.println(unitOf(measurement.signalType));
+      }
+      Serial.println();
+    }
+  }
+
+  // 2.3 Clear all mailboxes
+  for (int i = 0; i < maxNumSensors; i++) {
+    dataPointers[i] = nullptr;
+  }
+
+  // 2.4 Wait for 1000 milliseconds
+  delay(1000);
+};

--- a/examples/hacksterExample/platformio.ini
+++ b/examples/hacksterExample/platformio.ini
@@ -1,0 +1,40 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+[platformio]
+src_dir = .
+
+[env:hacksterExample]
+platform = espressif32
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    Sensirion/Sensirion Core
+    Sensirion/Sensirion UPT Core
+    ; Depends on version 0.1.0 (Newer versions have incompatible API)
+    Sensirion/Sensirion I2C SHT4x@0.1.0
+    Sensirion/Sensirion I2C SCD4x
+    Sensirion/Sensirion I2C SFA3x
+    Sensirion/Sensirion I2C SVM4x
+    Sensirion/Sensirion I2C SEN5X
+    Sensirion/Sensirion I2C SCD30
+    Sensirion/Sensirion I2C SGP41
+    Sensirion/Sensirion I2C STC3x
+    ; Grab local version of Autodetection
+    ; Users building their project in another location must instead add the line
+    ;   Sensirion/Sensirion UPT I2C Auto Detection
+    ; to their platformio.ini file, and may omit the sensor driver libraries.
+    Sensirion UPT I2C Auto Detection=file://../../src/
+
+; Find your parameter here: https://docs.platformio.org/en/latest/boards/index.html
+board = esp32dev
+
+; Makes this folder buildable in case there are files left over from using
+; environment hacksterExample in platformio.ini file two levels up
+build_src_filter = -<./hacksterExample.cpp> +<./hacksterExample.ino.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,21 +12,21 @@
 default_envs = basicUsage
 
 [common]
-lib_deps_builtin =
-    Wire
 lib_deps_external =
-    Sensirion Core
-    Sensirion UPT Core
-    Sensirion I2C SHT4x@0.1.0
-    Sensirion I2C SCD4x
-    Sensirion I2C SFA3x
-    Sensirion I2C SVM4x
-    Sensirion I2C SEN5X
-    Sensirion I2C SCD30
-    Sensirion I2C SGP41
-    Sensirion I2C STC3x
-basicUsage_srcdir = ${PROJECT_DIR}/examples/basicUsage/basicUsage.cpp
-advancedUsage_srcdir = ${PROJECT_DIR}/examples/advancedUsage/advancedUsage.cpp
+    Sensirion/Sensirion Core
+    Sensirion/Sensirion UPT Core
+    ; Newer versions of the SHT4X driver have an incompatible API
+    Sensirion/Sensirion I2C SHT4x@0.1.0
+    Sensirion/Sensirion I2C SCD4x
+    Sensirion/Sensirion I2C SFA3x
+    Sensirion/Sensirion I2C SVM4x
+    Sensirion/Sensirion I2C SEN5X
+    Sensirion/Sensirion I2C SCD30
+    Sensirion/Sensirion I2C SGP41
+    Sensirion/Sensirion I2C STC3x
+basicUsage_srcdir = ${PROJECT_DIR}/examples/basicUsage/
+advancedUsage_srcdir = ${PROJECT_DIR}/examples/advancedUsage/
+hacksterExample_srcdir = ${PROJECT_DIR}/examples/hacksterExample/
 
 ; Common environment settings
 [env]
@@ -34,10 +34,7 @@ platform = espressif32
 framework = arduino
 monitor_speed = 115200
 lib_deps =
-    ${common.lib_deps_builtin}
     ${common.lib_deps_external}
-lib_extra_dirs =
-	${PROJECT_DIR}/src/*
 extra_scripts =
     pre:py_scripts/make_cpp_files.py
 check_tool = cppcheck, clangtidy
@@ -51,9 +48,14 @@ check_src_filters =
 
 ; Board and example specific environments
 [env:basicUsage]
-build_src_filter = +<*> -<.git/> -<.svn/> +<${common.basicUsage_srcdir}>
+build_src_filter = +<*> -<.git/> +<${common.basicUsage_srcdir}>
 board = esp32dev
 
 [env:advancedUsage]
-build_src_filter = +<*> -<.git/> -<.svn/> +<${common.advancedUsage_srcdir}>
+build_src_filter = +<*> -<.git/> +<${common.advancedUsage_srcdir}>
+board = esp32dev
+
+[env:hacksterExample]
+; Please read the corresponding README in ./examples/hacksterExample
+build_src_filter = +<*> -<.git/> +<${common.hacksterExample_srcdir}> -<${common.hacksterExample_srcdir}/.pio/>
 board = esp32dev


### PR DESCRIPTION
See https://docs.platformio.org/en/latest/librarymanager/dependencies.html

and

https://docs.platformio.org/en/latest/projectconf/sections/env/options/library/lib_extra_dirs.html

for deviations from what we usually do in the .ini file.

Tested in both platformIO and ArduinoIDE (Seems to work fine)