### PR TITLE
Initialize meta data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Arduino Library for automatic detection of Sensirion sensors on an I2C Bus. It a
 - SVM4X
 
 ### Sensor Oddities
+- SCD30. This sensor has a particular method of retrieveing measurements, which typically enters a waiting loop until the measurement is ready. To avoid this blocking call, the library uses an alternative method, that sometimes yields I2C errors. These errors are not fatal and can be ignored.
 - SGP41. The SGP41 arduino I2C driver returns raw VOC and NOX values, as opposed to the SEN5X sensors, which internally feed the raw values through [Sensirion's gas index algorithm](https://github.com/Sensirion/gas-index-algorithm) and returns a gas index in the range of [0, 500].
 - STC3X. The STC3X requires a conditioning phase of up to 10 seconds (this library considers 8 sufficient), during which the value of the data points will be UNDEFINED/0.
 - SVM40. The SVM40 Evaluation Kit Board is deprecated and **not** supported by sensor autodetection.
@@ -65,13 +66,13 @@ To use the library, add the following dependencies to your `platformio.ini`'s `l
 
 ```control
 lib_deps =
-    Sensirion UPT I2C Auto Detection
+    Sensirion/Sensirion UPT I2C Auto Detection
 ```
 PlatformIO will automatically fetch the latest version of the dependencies during the build process.
 
 Alternatively, to install this library in your project environment execute the following command in a terminal:
 ```bash
-pio pkg install --library "Sensirion UPT I2C Auto Detection"
+pio pkg install --library "Sensirion/Sensirion UPT I2C Auto Detection"
 ```
 
 To test the default example (`basicUsage`), use the following platformio command from the project's root directory (the one containing the `platformio.ini` file):
@@ -118,7 +119,7 @@ In any case, the following steps are essential.
 
 Include the library:
 ```cpp
-    #include "Sensirion_Sensor_Auto_Detection.h"
+    #include "Sensirion_upt_i2c_auto_detection.h"
 ```
 Instantiate I2CAutoDetector and SensorManager globally (before void setup()):
 

--- a/src/ISensor.h
+++ b/src/ISensor.h
@@ -96,11 +96,18 @@ class ISensor {
     }
 
     /**
-     * @brief Get the specific SensorId of the ISensor realization
+     * @brief Get the specific SensorType of the ISensor realization
      *
-     * @return SensorId
+     * @return SensorType
      */
     virtual SensorType getSensorType() const = 0;
+
+    /**
+     * @brief Get the MetaData of the ISensor realization
+     * 
+     * @return MetaData
+    */
+    virtual MetaData getMetaData() const = 0;
 
     /**
      * @brief getter method for _NUMBER_OF_ALLOWED_CONSECUTIVE_ERRORS

--- a/src/ISensor.h
+++ b/src/ISensor.h
@@ -22,22 +22,10 @@ class ISensor {
     virtual uint16_t start() = 0;
 
     /**
-     * @brief Query sensor whether an initialization step is required or not.
-     *
-     * @param[out] bool true if either a conditioning or initialization command
-     * must be called before measurements are available
+     * @brief Perform extended sensor initialization (if applicable) and
+     * determines sensor metadata.
      */
-    virtual bool requiresInitializationStep() const {
-        return false;
-    };
-
-    /**
-     * @brief Perform extended sensor initialization.
-     * As most sensors don't require this, overriding this method is optional.
-     */
-    virtual uint16_t initializationStep() {
-        return 0;
-    };
+    virtual uint16_t initializationStep() = 0;
 
     /**
      * @brief Get the duration of the conditioning period
@@ -104,9 +92,9 @@ class ISensor {
 
     /**
      * @brief Get the MetaData of the ISensor realization
-     * 
+     *
      * @return MetaData
-    */
+     */
     virtual MetaData getMetaData() const = 0;
 
     /**

--- a/src/Sensirion_upt_i2c_auto_detection.h
+++ b/src/Sensirion_upt_i2c_auto_detection.h
@@ -1,8 +1,8 @@
 #ifndef _SENSIRION_UPT_I2C_AUTO_DETECTION_H_
 #define _SENSIRION_UPT_I2C_AUTO_DETECTION_H_
 
-#include "Sensirion_UPT_Core.h"
 #include "I2CAutoDetector.h"
+#include "Sensirion_UPT_Core.h"
 #include "SensorManager.h"
 #include <Arduino.h>
 

--- a/src/SensorStateMachine.cpp
+++ b/src/SensorStateMachine.cpp
@@ -18,33 +18,30 @@ SensorStateMachine::SensorStateMachine(ISensor* pSensor)
 };
 
 AutoDetectorError SensorStateMachine::_initialize() {
-    if (_sensor->requiresInitializationStep()) {
-        uint16_t error = _sensor->initializationStep();
-        if (error) {
-            char errorMsg[256];
-            errorToString(error, errorMsg, 256);
-            Serial.printf("Failed to perform initialization step: %s\n",
-                          errorMsg);
-            return I2C_ERROR;
-        }
-
-        _lastMeasurementTimeStampMs = millis();
-        _sensorState = SensorStatus::INITIALIZING;
-
-        _sensorSignals.init(_sensor->getNumberOfDataPoints());
-
-        for (size_t i = 0; i < _sensor->getNumberOfDataPoints(); ++i) {
-            Measurement measurement;
-            measurement.metaData = _sensor->getMetaData();
-            _sensorSignals.addMeasurement(measurement);
-        }
-
-    } else {
-        _sensorState = SensorStatus::RUNNING;
-        _sensorSignals.init(_sensor->getNumberOfDataPoints());
+    uint16_t error = _sensor->initializationStep();
+    if (error) {
+        char errorMsg[256];
+        errorToString(error, errorMsg, 256);
+        Serial.printf("Failed to perform initialization step: %s\n", errorMsg);
+        return I2C_ERROR;
     }
 
+    _sensorSignals.init(_sensor->getNumberOfDataPoints());
     _measurementIntervalMs = _sensor->getMinimumMeasurementIntervalMs();
+    _lastMeasurementTimeStampMs = millis();
+
+    if (_sensor->getInitializationIntervalMs() > 0) {
+        // SGP4X, SCD4X
+        _sensorState = SensorStatus::INITIALIZING;
+    } else {
+        _sensorState = SensorStatus::RUNNING;
+    }
+
+    for (size_t i = 0; i < _sensor->getNumberOfDataPoints(); ++i) {
+        Measurement measurement;
+        measurement.metaData = _sensor->getMetaData();
+        _sensorSignals.addMeasurement(measurement);
+    }
 
     return NO_ERROR;
 }

--- a/src/SensorStateMachine.cpp
+++ b/src/SensorStateMachine.cpp
@@ -35,6 +35,7 @@ AutoDetectorError SensorStateMachine::_initialize() {
 
         for (size_t i = 0; i < _sensor->getNumberOfDataPoints(); ++i) {
             Measurement measurement;
+            measurement.metaData = _sensor->getMetaData();
             _sensorSignals.addMeasurement(measurement);
         }
 

--- a/src/SensorWrappers/Scd30.cpp
+++ b/src/SensorWrappers/Scd30.cpp
@@ -100,10 +100,6 @@ unsigned long Scd30::getMinimumMeasurementIntervalMs() const {
     return 2000;
 }
 
-bool Scd30::requiresInitializationStep() const {
-    return true;
-}
-
 void* Scd30::getDriver() {
     return reinterpret_cast<void*>(&_driver);
 }

--- a/src/SensorWrappers/Scd30.h
+++ b/src/SensorWrappers/Scd30.h
@@ -17,7 +17,6 @@ class Scd30 : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
     void* getDriver() override;
 
   private:

--- a/src/SensorWrappers/Scd30.h
+++ b/src/SensorWrappers/Scd30.h
@@ -8,12 +8,13 @@
 class Scd30 : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x61;
-    explicit Scd30(TwoWire& wire) : _wire(wire){};
+    explicit Scd30(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -22,8 +23,7 @@ class Scd30 : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2cScd30 _driver;
-    const SensorType _sensorType = SensorType::SCD30;
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
 };
 
 #endif /* _SCD30_H_ */

--- a/src/SensorWrappers/Scd4x.cpp
+++ b/src/SensorWrappers/Scd4x.cpp
@@ -2,6 +2,11 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
+Scd4x::Scd4x(TwoWire& wire) : _wire(wire) {
+    _metaData.deviceType.sensorType = SensorType::SCD4X;
+    _metaData.platform = DevicePlatform::WIRED;
+};
+
 uint16_t Scd4x::start() {
     _driver.begin(_wire);
     return 0;
@@ -17,25 +22,20 @@ uint16_t Scd4x::measureAndWrite(Measurement measurements[],
         return error;
     }
 
-    MetaData metaData;
-    metaData.deviceID = _sensorID;
-    metaData.deviceType.sensorType = _sensorType;
-    metaData.platform = DevicePlatform::WIRED;
-
     measurements[0].signalType = SignalType::CO2_PARTS_PER_MILLION;
     measurements[0].dataPoint.t_offset = timeStamp;
     measurements[0].dataPoint.value = static_cast<float>(co2);
-    measurements[0].metaData = metaData;
+    measurements[0].metaData = _metaData;
 
     measurements[1].signalType = SignalType::TEMPERATURE_DEGREES_CELSIUS;
     measurements[1].dataPoint.t_offset = timeStamp;
     measurements[1].dataPoint.value = temp;
-    measurements[1].metaData = metaData;
+    measurements[1].metaData = _metaData;
 
     measurements[2].signalType = SignalType::RELATIVE_HUMIDITY_PERCENTAGE;
     measurements[2].dataPoint.t_offset = timeStamp;
     measurements[2].dataPoint.value = humi;
-    measurements[2].metaData = metaData;
+    measurements[2].metaData = _metaData;
 
     return HighLevelError::NoError;
 }
@@ -52,9 +52,11 @@ uint16_t Scd4x::initializationStep() {
     if (error) {
         return error;
     }
-    _sensorID = 0;
-    _sensorID |=
+    uint64_t sensorID = 0;
+    sensorID |=
         (static_cast<uint64_t>(word0) << 16 * 2) | (word1 << 16) | word2;
+
+    _metaData.deviceID = sensorID;
 
     // Start Measurement
     error = _driver.startPeriodicMeasurement();
@@ -62,7 +64,11 @@ uint16_t Scd4x::initializationStep() {
 }
 
 SensorType Scd4x::getSensorType() const {
-    return _sensorType;
+    return _metaData.deviceType.sensorType;
+}
+
+MetaData Scd4x::getMetaData() const {
+    return _metaData;
 }
 
 size_t Scd4x::getNumberOfDataPoints() const {

--- a/src/SensorWrappers/Scd4x.cpp
+++ b/src/SensorWrappers/Scd4x.cpp
@@ -79,8 +79,10 @@ unsigned long Scd4x::getMinimumMeasurementIntervalMs() const {
     return 5000;
 }
 
-bool Scd4x::requiresInitializationStep() const {
-    return true;
+unsigned long Scd4x::getInitializationIntervalMs() const {
+    // Sensor does not produce measurements for ~12s after
+    // startPeriodicMeasurement() is called
+    return 12 * 1000;
 }
 
 void* Scd4x::getDriver() {

--- a/src/SensorWrappers/Scd4x.h
+++ b/src/SensorWrappers/Scd4x.h
@@ -17,7 +17,8 @@ class Scd4x : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
+    // Same as measurement interval
+    unsigned long getInitializationIntervalMs() const override;
     void* getDriver() override;
 
   private:

--- a/src/SensorWrappers/Scd4x.h
+++ b/src/SensorWrappers/Scd4x.h
@@ -8,12 +8,13 @@
 class Scd4x : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x62;
-    explicit Scd4x(TwoWire& wire) : _wire(wire){};
+    explicit Scd4x(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -22,8 +23,7 @@ class Scd4x : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CScd4x _driver;
-    const SensorType _sensorType = SensorType::SCD4X;
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
 };
 
 #endif /* _SCD4X_H_ */

--- a/src/SensorWrappers/Sen5x.cpp
+++ b/src/SensorWrappers/Sen5x.cpp
@@ -151,10 +151,6 @@ unsigned long Sen5x::getMinimumMeasurementIntervalMs() const {
     return 1000;
 }
 
-bool Sen5x::requiresInitializationStep() const {
-    return true;
-}
-
 void* Sen5x::getDriver() {
     return reinterpret_cast<void*>(&_driver);
 }

--- a/src/SensorWrappers/Sen5x.cpp
+++ b/src/SensorWrappers/Sen5x.cpp
@@ -1,6 +1,12 @@
 #include "SensorWrappers/Sen5x.h"
 #include "SensirionCore.h"
 
+Sen5x::Sen5x(TwoWire& wire) : _wire(wire) {
+    _metaData.deviceType.sensorType =
+        SensorType::SEN5X;  // determined more precisely in initializationStep()
+    _metaData.platform = DevicePlatform::WIRED;
+};
+
 uint16_t Sen5x::start() {
     _driver.begin(_wire);
     return 0;
@@ -29,55 +35,51 @@ uint16_t Sen5x::measureAndWrite(Measurement measurements[],
         return error;
     }
 
-    MetaData metaData;
-    metaData.deviceID = _sensorID;
-    metaData.deviceType.sensorType = _sensorType;
-    metaData.platform = DevicePlatform::WIRED;
-
     // Versions 50, 54 and 55
     measurements[0].signalType = SignalType::PM1P0_MICRO_GRAMM_PER_CUBIC_METER;
     measurements[0].dataPoint.t_offset = timeStamp;
     measurements[0].dataPoint.value = massConcentrationPm1p0;
-    measurements[0].metaData = metaData;
+    measurements[0].metaData = _metaData;
 
     measurements[1].signalType = SignalType::PM2P5_MICRO_GRAMM_PER_CUBIC_METER;
     measurements[1].dataPoint.t_offset = timeStamp;
     measurements[1].dataPoint.value = massConcentrationPm2p5;
-    measurements[1].metaData = metaData;
+    measurements[1].metaData = _metaData;
 
     measurements[2].signalType = SignalType::PM4P0_MICRO_GRAMM_PER_CUBIC_METER;
     measurements[2].dataPoint.t_offset = timeStamp;
     measurements[2].dataPoint.value = massConcentrationPm4p0;
-    measurements[2].metaData = metaData;
+    measurements[2].metaData = _metaData;
 
     measurements[3].signalType = SignalType::PM10P0_MICRO_GRAMM_PER_CUBIC_METER;
     measurements[3].dataPoint.t_offset = timeStamp;
     measurements[3].dataPoint.value = massConcentrationPm10p0;
-    measurements[3].metaData = metaData;
+    measurements[3].metaData = _metaData;
 
     // Verions 54, 55
-    if (_sensorType == SensorType::SEN54 or _sensorType == SensorType::SEN55) {
+    if (getSensorType() == SensorType::SEN54 or
+        getSensorType() == SensorType::SEN55) {
         measurements[4].signalType = SignalType::RELATIVE_HUMIDITY_PERCENTAGE;
         measurements[4].dataPoint.t_offset = timeStamp;
         measurements[4].dataPoint.value = ambientHumidity;
-        measurements[4].metaData = metaData;
+        measurements[4].metaData = _metaData;
 
         measurements[5].signalType = SignalType::TEMPERATURE_DEGREES_CELSIUS;
         measurements[5].dataPoint.t_offset = timeStamp;
         measurements[5].dataPoint.value = ambientTemperature;
-        measurements[5].metaData = metaData;
+        measurements[5].metaData = _metaData;
 
         measurements[6].signalType = SignalType::VOC_INDEX;
         measurements[6].dataPoint.t_offset = timeStamp;
         measurements[6].dataPoint.value = vocIndex;
-        measurements[6].metaData = metaData;
+        measurements[6].metaData = _metaData;
     }
     // Version 55
-    if (_sensorType == SensorType::SEN55) {
+    if (getSensorType() == SensorType::SEN55) {
         measurements[7].signalType = SignalType::NOX_INDEX;
         measurements[7].dataPoint.t_offset = timeStamp;
         measurements[7].dataPoint.value = noxIndex;
-        measurements[7].metaData = metaData;
+        measurements[7].metaData = _metaData;
     }
     return HighLevelError::NoError;
 }
@@ -104,12 +106,14 @@ uint16_t Sen5x::initializationStep() {
     }
     size_t actualLen = strlen((const char*)serialNumber);
     size_t numBytesToCopy = min(8, (int)actualLen);
-    _sensorID = 0;
+    uint64_t sensorID = 0;
     for (int i = 0; i < numBytesToCopy - 1; i++) {
-        _sensorID |= (serialNumber[actualLen - numBytesToCopy - 1 + i]);
-        _sensorID = _sensorID << 8;
+        sensorID |= (serialNumber[actualLen - numBytesToCopy - 1 + i]);
+        sensorID = sensorID << 8;
     }
-    _sensorID |= serialNumber[actualLen - 1];
+    sensorID |= serialNumber[actualLen - 1];
+
+    _metaData.deviceID = sensorID;
 
     // Start Measurement
     error = _driver.startMeasurement();
@@ -121,11 +125,15 @@ uint16_t Sen5x::initializationStep() {
 }
 
 SensorType Sen5x::getSensorType() const {
-    return _sensorType;
+    return _metaData.deviceType.sensorType;
+}
+
+MetaData Sen5x::getMetaData() const {
+    return _metaData;
 }
 
 size_t Sen5x::getNumberOfDataPoints() const {
-    switch (_sensorType) {
+    switch (getSensorType()) {
         case SensorType::SEN5X:
             return 4;
         case SensorType::SEN50:
@@ -161,15 +169,15 @@ uint16_t Sen5x::_determineSensorVersion() {
     }
 
     if (strcmp(reinterpret_cast<const char*>(sensorNameStr), "SEN50") == 0) {
-        _sensorType = SensorType::SEN50;
+        _metaData.deviceType.sensorType = SensorType::SEN50;
     } else if (strcmp(reinterpret_cast<const char*>(sensorNameStr), "SEN54") ==
                0) {
-        _sensorType = SensorType::SEN54;
+        _metaData.deviceType.sensorType = SensorType::SEN54;
     } else if (strcmp(reinterpret_cast<const char*>(sensorNameStr), "SEN55") ==
                0) {
-        _sensorType = SensorType::SEN55;
+        _metaData.deviceType.sensorType = SensorType::SEN55;
     } else {
-        _sensorType = SensorType::SEN5X;
+        _metaData.deviceType.sensorType = SensorType::SEN5X;
     }
     return 0;
 }

--- a/src/SensorWrappers/Sen5x.h
+++ b/src/SensorWrappers/Sen5x.h
@@ -8,12 +8,13 @@
 class Sen5x : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x69;
-    explicit Sen5x(TwoWire& wire) : _wire(wire){};
+    explicit Sen5x(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -22,9 +23,7 @@ class Sen5x : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CSen5x _driver;
-    SensorType _sensorType =
-        SensorType::SEN5X;  // determined more precisely in initializationStep()
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
     uint16_t _determineSensorVersion();
 };
 

--- a/src/SensorWrappers/Sen5x.h
+++ b/src/SensorWrappers/Sen5x.h
@@ -17,7 +17,6 @@ class Sen5x : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
     void* getDriver() override;
 
   private:

--- a/src/SensorWrappers/Sfa3x.cpp
+++ b/src/SensorWrappers/Sfa3x.cpp
@@ -1,6 +1,11 @@
 #include "SensorWrappers/Sfa3x.h"
 #include "SensirionCore.h"
 
+Sfa3x::Sfa3x(TwoWire& wire) : _wire(wire) {
+    _metaData.deviceType.sensorType = SensorType::SFA3X;
+    _metaData.platform = DevicePlatform::WIRED;
+};
+
 uint16_t Sfa3x::start() {
     _driver.begin(_wire);
     return 0;
@@ -17,25 +22,20 @@ uint16_t Sfa3x::measureAndWrite(Measurement measurements[],
         return error;
     }
 
-    MetaData metaData;
-    metaData.deviceID = _sensorID;
-    metaData.deviceType.sensorType = _sensorType;
-    metaData.platform = DevicePlatform::WIRED;
-
     measurements[0].signalType = SignalType::HCHO_PARTS_PER_BILLION;
     measurements[0].dataPoint.t_offset = timeStamp;
     measurements[0].dataPoint.value = static_cast<float>(hcho) / 5.0f;
-    measurements[0].metaData = metaData;
+    measurements[0].metaData = _metaData;
 
     measurements[1].signalType = SignalType::RELATIVE_HUMIDITY_PERCENTAGE;
     measurements[1].dataPoint.t_offset = timeStamp;
     measurements[1].dataPoint.value = static_cast<float>(humi) / 100.0f;
-    measurements[1].metaData = metaData;
+    measurements[1].metaData = _metaData;
 
     measurements[2].signalType = SignalType::TEMPERATURE_DEGREES_CELSIUS;
     measurements[2].dataPoint.t_offset = timeStamp;
     measurements[2].dataPoint.value = static_cast<float>(temp) / 200.0f;
-    measurements[2].metaData = metaData;
+    measurements[2].metaData = _metaData;
 
     return HighLevelError::NoError;
 }
@@ -55,19 +55,25 @@ uint16_t Sfa3x::initializationStep() {
     size_t actualLen = strlen((const char*)serialNumber);
     size_t numBytesToCopy = min(8, (int)actualLen);
 
-    _sensorID = 0;
+    uint64_t sensorID = 0;
     for (int i = 0; i < numBytesToCopy - 1; i++) {
-        _sensorID |= (serialNumber[actualLen - numBytesToCopy - 1 + i]);
-        _sensorID = _sensorID << 8;
+        sensorID |= (serialNumber[actualLen - numBytesToCopy - 1 + i]);
+        sensorID = sensorID << 8;
     }
-    _sensorID |= serialNumber[actualLen - 1];
+    sensorID |= serialNumber[actualLen - 1];
+
+    _metaData.deviceID = sensorID;
 
     error = _driver.startContinuousMeasurement();
     return error;
 }
 
 SensorType Sfa3x::getSensorType() const {
-    return _sensorType;
+    return _metaData.deviceType.sensorType;
+}
+
+MetaData Sfa3x::getMetaData() const {
+    return _metaData;
 }
 
 size_t Sfa3x::getNumberOfDataPoints() const {

--- a/src/SensorWrappers/Sfa3x.cpp
+++ b/src/SensorWrappers/Sfa3x.cpp
@@ -84,10 +84,6 @@ unsigned long Sfa3x::getMinimumMeasurementIntervalMs() const {
     return 5000;
 }
 
-bool Sfa3x::requiresInitializationStep() const {
-    return true;
-}
-
 void* Sfa3x::getDriver() {
     return reinterpret_cast<void*>(&_driver);
 }

--- a/src/SensorWrappers/Sfa3x.h
+++ b/src/SensorWrappers/Sfa3x.h
@@ -8,12 +8,13 @@
 class Sfa3x : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x5D;
-    explicit Sfa3x(TwoWire& wire) : _wire(wire){};
+    explicit Sfa3x(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -22,8 +23,7 @@ class Sfa3x : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CSfa3x _driver;
-    const SensorType _sensorType = SensorType::SFA3X;
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
 };
 
 #endif /* _SFA3X_H_ */

--- a/src/SensorWrappers/Sfa3x.h
+++ b/src/SensorWrappers/Sfa3x.h
@@ -17,7 +17,6 @@ class Sfa3x : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
     void* getDriver() override;
 
   private:

--- a/src/SensorWrappers/Sgp4x.cpp
+++ b/src/SensorWrappers/Sgp4x.cpp
@@ -69,10 +69,6 @@ unsigned long Sgp41::getMinimumMeasurementIntervalMs() const {
     return 1000;
 }
 
-bool Sgp41::requiresInitializationStep() const {
-    return true;
-}
-
 unsigned long Sgp41::getInitializationIntervalMs() const {
     return 8000;
 }

--- a/src/SensorWrappers/Sgp4x.cpp
+++ b/src/SensorWrappers/Sgp4x.cpp
@@ -2,6 +2,11 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
+Sgp41::Sgp41(TwoWire& wire) : _wire(wire) {
+    _metaData.deviceType.sensorType = SensorType::SGP4X;
+    _metaData.platform = DevicePlatform::WIRED;
+};
+
 uint16_t Sgp41::start() {
     _driver.begin(_wire);
     return 0;
@@ -17,20 +22,16 @@ uint16_t Sgp41::measureAndWrite(Measurement measurements[],
     if (error) {
         return error;
     }
-    MetaData metaData;
-    metaData.deviceID = _sensorID;
-    metaData.deviceType.sensorType = _sensorType;
-    metaData.platform = DevicePlatform::WIRED;
 
     measurements[0].signalType = SignalType::RAW_VOC_INDEX;
     measurements[0].dataPoint.t_offset = timeStamp;
     measurements[0].dataPoint.value = static_cast<float>(srawVoc);
-    measurements[0].metaData = metaData;
+    measurements[0].metaData = _metaData;
 
     measurements[1].signalType = SignalType::RAW_NOX_INDEX;
     measurements[1].dataPoint.t_offset = timeStamp;
     measurements[1].dataPoint.value = static_cast<float>(srawNox);
-    measurements[1].metaData = metaData;
+    measurements[1].metaData = _metaData;
 
     return HighLevelError::NoError;
 }
@@ -42,9 +43,10 @@ uint16_t Sgp41::initializationStep() {
     if (error) {
         return error;
     }
-    _sensorID = 0;
-    _sensorID |= (static_cast<uint64_t>(serialNo[0]) << 16 * 2) |
-                 (serialNo[1] << 16) | serialNo[2];
+    uint64_t sensorID = 0;
+    sensorID |= (static_cast<uint64_t>(serialNo[0]) << 16 * 2) |
+                (serialNo[1] << 16) | serialNo[2];
+    _metaData.deviceID = sensorID;
 
     uint16_t srawVoc;  // discarded during initialization
     error = _driver.executeConditioning(_defaultRh, _defaultT, srawVoc);
@@ -52,7 +54,11 @@ uint16_t Sgp41::initializationStep() {
 }
 
 SensorType Sgp41::getSensorType() const {
-    return _sensorType;
+    return _metaData.deviceType.sensorType;
+}
+
+MetaData Sgp41::getMetaData() const {
+    return _metaData;
 }
 
 size_t Sgp41::getNumberOfDataPoints() const {

--- a/src/SensorWrappers/Sgp4x.h
+++ b/src/SensorWrappers/Sgp4x.h
@@ -17,7 +17,6 @@ class Sgp41 : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
 
     // Typical: 10s
     unsigned long getInitializationIntervalMs() const override;

--- a/src/SensorWrappers/Sgp4x.h
+++ b/src/SensorWrappers/Sgp4x.h
@@ -8,12 +8,13 @@
 class Sgp41 : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x59;
-    explicit Sgp41(TwoWire& wire) : _wire(wire){};
+    explicit Sgp41(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -28,8 +29,7 @@ class Sgp41 : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CSgp41 _driver;
-    const SensorType _sensorType = SensorType::SGP4X;
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
     uint16_t _defaultRh = 0x8000;
     uint16_t _defaultT = 0x6666;
 };

--- a/src/SensorWrappers/Sht4x.cpp
+++ b/src/SensorWrappers/Sht4x.cpp
@@ -2,6 +2,11 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
+Sht4x::Sht4x(TwoWire& wire) : _wire(wire) {
+    _metaData.deviceType.sensorType = SensorType::SHT4X;
+    _metaData.platform = DevicePlatform::WIRED;
+};
+
 uint16_t Sht4x::start() {
     _driver.begin(_wire);
     return HighLevelError::NoError;
@@ -9,11 +14,11 @@ uint16_t Sht4x::start() {
 
 uint16_t Sht4x::measureAndWrite(Measurement measurements[],
                                 const unsigned long timeStamp) {
-    if (_sensorID == 0) {
+    if (_metaData.deviceID == 0) {
         // Read sensor identifier at first measurement retrieval
         uint32_t serialNo;
         _driver.serialNumber(serialNo);
-        _sensorID = static_cast<uint64_t>(serialNo);
+        _metaData.deviceID = static_cast<uint64_t>(serialNo);
     }
 
     float temp;
@@ -23,26 +28,25 @@ uint16_t Sht4x::measureAndWrite(Measurement measurements[],
         return error;
     }
 
-    MetaData metaData;
-    metaData.deviceID = _sensorID;
-    metaData.deviceType.sensorType = _sensorType;
-    metaData.platform = DevicePlatform::WIRED;
-
     measurements[0].signalType = SignalType::TEMPERATURE_DEGREES_CELSIUS;
     measurements[0].dataPoint.t_offset = timeStamp;
     measurements[0].dataPoint.value = temp;
-    measurements[0].metaData = metaData;
+    measurements[0].metaData = _metaData;
 
     measurements[1].signalType = SignalType::RELATIVE_HUMIDITY_PERCENTAGE;
     measurements[1].dataPoint.t_offset = timeStamp;
     measurements[1].dataPoint.value = humi;
-    measurements[1].metaData = metaData;
+    measurements[1].metaData = _metaData;
 
     return HighLevelError::NoError;
 }
 
 SensorType Sht4x::getSensorType() const {
-    return _sensorType;
+    return _metaData.deviceType.sensorType;
+}
+
+MetaData Sht4x::getMetaData() const {
+    return _metaData;
 }
 
 size_t Sht4x::getNumberOfDataPoints() const {

--- a/src/SensorWrappers/Sht4x.cpp
+++ b/src/SensorWrappers/Sht4x.cpp
@@ -14,13 +14,6 @@ uint16_t Sht4x::start() {
 
 uint16_t Sht4x::measureAndWrite(Measurement measurements[],
                                 const unsigned long timeStamp) {
-    if (_metaData.deviceID == 0) {
-        // Read sensor identifier at first measurement retrieval
-        uint32_t serialNo;
-        _driver.serialNumber(serialNo);
-        _metaData.deviceID = static_cast<uint64_t>(serialNo);
-    }
-
     float temp;
     float humi;
     uint16_t error = _driver.measureHighPrecision(temp, humi);
@@ -39,6 +32,16 @@ uint16_t Sht4x::measureAndWrite(Measurement measurements[],
     measurements[1].metaData = _metaData;
 
     return HighLevelError::NoError;
+}
+
+uint16_t Sht4x::initializationStep() {
+    uint32_t serialNo;
+    uint16_t error = _driver.serialNumber(serialNo);
+    if (error) {
+        return error;
+    }
+    _metaData.deviceID = static_cast<uint64_t>(serialNo);
+    return error;
 }
 
 SensorType Sht4x::getSensorType() const {

--- a/src/SensorWrappers/Sht4x.h
+++ b/src/SensorWrappers/Sht4x.h
@@ -12,6 +12,7 @@ class Sht4x : public ISensor {
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
+    uint16_t initializationStep() override;
     SensorType getSensorType() const override;
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;

--- a/src/SensorWrappers/Sht4x.h
+++ b/src/SensorWrappers/Sht4x.h
@@ -8,11 +8,12 @@
 class Sht4x : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x44;
-    explicit Sht4x(TwoWire& wire) : _wire(wire){};
+    explicit Sht4x(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     void* getDriver() override;
@@ -20,8 +21,7 @@ class Sht4x : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CSht4x _driver;
-    const SensorType _sensorType = SensorType::SHT4X;
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
 };
 
 #endif /* _SHT4X_H_ */

--- a/src/SensorWrappers/Stc3x.cpp
+++ b/src/SensorWrappers/Stc3x.cpp
@@ -118,10 +118,6 @@ unsigned long Stc3x::getMinimumMeasurementIntervalMs() const {
     return 1000;
 }
 
-bool Stc3x::requiresInitializationStep() const {
-    return 1;
-}
-
 void* Stc3x::getDriver() {
     return reinterpret_cast<void*>(&_driver);
 }

--- a/src/SensorWrappers/Stc3x.cpp
+++ b/src/SensorWrappers/Stc3x.cpp
@@ -2,6 +2,12 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
+Stc3x::Stc3x(TwoWire& wire) : _wire(wire) {
+    _metaData.deviceType.sensorType =
+        SensorType::STC3X;  // Determined more precisely at initializationStep()
+    _metaData.platform = DevicePlatform::WIRED;
+};
+
 uint16_t Stc3x::start() {
     _driver.begin(_wire);
     uint16_t error = _driver.setBinaryGas(0x0001);
@@ -19,23 +25,18 @@ uint16_t Stc3x::measureAndWrite(Measurement measurements[],
         return error;
     }
 
-    MetaData metaData;
-    metaData.deviceID = _sensorID;
-    metaData.deviceType.sensorType = _sensorType;
-    metaData.platform = DevicePlatform::WIRED;
-
     measurements[0].signalType =
         SignalType::GAS_CONCENTRATION_VOLUME_PERCENTAGE;
     measurements[0].dataPoint.t_offset = timeStamp;
     measurements[0].dataPoint.value =
         100 * (static_cast<float>(gasTicks) - 16384.0) / 32768.0;
-    measurements[0].metaData = metaData;
+    measurements[0].metaData = _metaData;
 
     measurements[1].signalType = SignalType::TEMPERATURE_DEGREES_CELSIUS;
     measurements[1].dataPoint.t_offset = timeStamp;
     measurements[1].dataPoint.value =
         static_cast<float>(temperatureTicks) / 200.0;
-    measurements[1].metaData = metaData;
+    measurements[1].metaData = _metaData;
 
     return HighLevelError::NoError;
 }
@@ -66,19 +67,20 @@ uint16_t Stc3x::initializationStep() {
     const uint32_t maskedProductNo = productNumber & mask;
     const uint32_t maskedSTC31ProductNo = stc31ProductNumber & mask;
     if (maskedSTC31ProductNo == maskedProductNo) {
-        _sensorType = SensorType::STC31;
+        _metaData.deviceType.sensorType = SensorType::STC31;
     }  // else keep default STC3X
 
     // Sensor Serial No
-    _sensorID = 0;
-    _sensorID |= (uint64_t)serialNumberRaw[0] << 56 |
-                 (uint64_t)serialNumberRaw[1] << 48 |
-                 (uint64_t)serialNumberRaw[2] << 40 |
-                 (uint64_t)serialNumberRaw[3] << 32 |
-                 (uint64_t)serialNumberRaw[4] << 24 |
-                 (uint64_t)serialNumberRaw[5] << 16 |
-                 (uint64_t)serialNumberRaw[6] << 8 |
-                 (uint64_t)serialNumberRaw[7];
+    uint64_t sensorID = 0;
+    sensorID |= (uint64_t)serialNumberRaw[0] << 56 |
+                (uint64_t)serialNumberRaw[1] << 48 |
+                (uint64_t)serialNumberRaw[2] << 40 |
+                (uint64_t)serialNumberRaw[3] << 32 |
+                (uint64_t)serialNumberRaw[4] << 24 |
+                (uint64_t)serialNumberRaw[5] << 16 |
+                (uint64_t)serialNumberRaw[6] << 8 |
+                (uint64_t)serialNumberRaw[7];
+    _metaData.deviceID = sensorID;
 
     // Select gas mode
     /**
@@ -101,7 +103,11 @@ uint16_t Stc3x::initializationStep() {
 }
 
 SensorType Stc3x::getSensorType() const {
-    return _sensorType;
+    return _metaData.deviceType.sensorType;
+}
+
+MetaData Stc3x::getMetaData() const {
+    return _metaData;
 }
 
 size_t Stc3x::getNumberOfDataPoints() const {

--- a/src/SensorWrappers/Stc3x.h
+++ b/src/SensorWrappers/Stc3x.h
@@ -8,12 +8,13 @@
 class Stc3x : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x29;
-    explicit Stc3x(TwoWire& wire) : _wire(wire){};
+    explicit Stc3x(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -22,9 +23,7 @@ class Stc3x : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CStc3x _driver;
-    SensorType _sensorType =
-        SensorType::STC3X;  // Determined more precisely at initializationStep()
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
 };
 
 #endif /* _STC3X_H_ */

--- a/src/SensorWrappers/Stc3x.h
+++ b/src/SensorWrappers/Stc3x.h
@@ -17,7 +17,6 @@ class Stc3x : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
     void* getDriver() override;
 
   private:

--- a/src/SensorWrappers/Svm4x.cpp
+++ b/src/SensorWrappers/Svm4x.cpp
@@ -91,10 +91,6 @@ unsigned long Svm4x::getMinimumMeasurementIntervalMs() const {
     return 1000;
 }
 
-bool Svm4x::requiresInitializationStep() const {
-    return true;
-}
-
 void* Svm4x::getDriver() {
     return reinterpret_cast<void*>(&_driver);
 }

--- a/src/SensorWrappers/Svm4x.h
+++ b/src/SensorWrappers/Svm4x.h
@@ -8,12 +8,13 @@
 class Svm4x : public ISensor {
   public:
     static const uint16_t I2C_ADDRESS = 0x6A;
-    explicit Svm4x(TwoWire& wire) : _wire(wire){};
+    explicit Svm4x(TwoWire& wire);
     uint16_t start() override;
     uint16_t measureAndWrite(Measurement measurements[],
                              const unsigned long timeStamp) override;
     uint16_t initializationStep() override;
     SensorType getSensorType() const override;
+    MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
     bool requiresInitializationStep() const override;
@@ -22,8 +23,7 @@ class Svm4x : public ISensor {
   private:
     TwoWire& _wire;
     SensirionI2CSvm41 _driver;
-    const SensorType _sensorType = SensorType::SVM41;
-    uint64_t _sensorID = 0;
+    MetaData _metaData;
 };
 
 #endif /* _SVM40_H_ */

--- a/src/SensorWrappers/Svm4x.h
+++ b/src/SensorWrappers/Svm4x.h
@@ -17,7 +17,6 @@ class Svm4x : public ISensor {
     MetaData getMetaData() const override;
     size_t getNumberOfDataPoints() const override;
     unsigned long getMinimumMeasurementIntervalMs() const override;
-    bool requiresInitializationStep() const override;
     void* getDriver() override;
 
   private:


### PR DESCRIPTION
In order to not obtain duplicates for uninitialized sensors in applications such as Stornella it is necessary to poll sensors for a device ID as soon as possible. Thus, each state machine is given a MetaData member, to be instantiated as soon as possible.

This change enabled a simplification of the state machine logic because every sensor now has an initialization step, to determine the sensor version.