### PR TITLE
Fix issue with probing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ latex
 src/html/**
 src/latex/**
 examples/**/*.cpp
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1]
+
+### Fixed
+- Fix probing not working without power cycle for certain sensors, if e.g. a measurement was still ongoing.
+
 ## [3.0.0]
 
 ### Added

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sensirion UPT I2C Auto Detection
-version=3.0.0
+version=3.0.1
 author=Jonas Stolle, Maximilian Paulsen
 maintainer=Sensirion AG <sensirion.com>
 sentence=Automatically detects Sensirion Sensors on an I2C bus and reads out measurement data.

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,14 +13,14 @@ default_envs = basicUsage
 
 [common]
 lib_deps_external =
-    Sensirion/Sensirion Core@0.7.1
+    Sensirion/Sensirion Core@0.7.2
     Sensirion/Sensirion UPT Core@^1.0.0
     Sensirion/Sensirion I2C SHT4x@1.1.2
     Sensirion/Sensirion I2C SCD4x@1.1.0
     Sensirion/Sensirion I2C SFA3x@1.0.0
     Sensirion/Sensirion I2C SVM4x@0.2.0
     Sensirion/Sensirion I2C SEN5X@0.3.0
-    Sensirion/Sensirion I2C SCD30@0.1.0
+    Sensirion/Sensirion I2C SCD30@1.0.0
     Sensirion/Sensirion I2C SGP41@1.0.0
     Sensirion/Sensirion I2C STC3x@1.0.1
     Sensirion/Sensirion I2C SEN66@1.1.0

--- a/src/SensorWrappers/Scd30.cpp
+++ b/src/SensorWrappers/Scd30.cpp
@@ -2,10 +2,10 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
-Scd30::Scd30(TwoWire& wire, const uint16_t address) : 
-    mWire(wire), mAddress{address}, mMetadata{core::SCD30()}{};
+Scd30::Scd30(TwoWire& wire, const uint16_t address)
+    : mWire(wire), mAddress{address}, mMetadata{core::SCD30()} {};
 
 uint16_t Scd30::start() {
     mDriver.begin(mWire, mAddress);
@@ -24,7 +24,6 @@ uint16_t Scd30::measureAndWrite(MeasurementList& measurements,
         return 1;
     }
 
-  
     float co2Concentration;
     float temperature;
     float humidity;
@@ -34,22 +33,21 @@ uint16_t Scd30::measureAndWrite(MeasurementList& measurements,
         return error;
     }
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::CO2_PARTS_PER_MILLION,
-        core::DataPoint{timeStamp, co2Concentration});
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::CO2_PARTS_PER_MILLION,
+                              core::DataPoint{timeStamp, co2Concentration});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS, 
-        core::DataPoint{timeStamp, temperature});
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              core::DataPoint{timeStamp, temperature});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE, 
-        core::DataPoint{timeStamp, humidity});
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+                              core::DataPoint{timeStamp, humidity});
 
-
-    /* Prepare next reading by querying the dataReadyFlag. We don't need the
+    /* Prepare the next reading by querying the dataReadyFlag. We don't need the
      * value of the flag, but the query seems to finalize setting off the
-     * measurement process, and enables much faster signal readout at the next
+     * measurement process and enables a much faster signal readout at the next
      * call of this function as it then is not required to enter a wait loop
      * (see SensirionI2cScd30::blockingReadMeasurementData()). This procedure is
      * only required for SCD30. */
@@ -57,7 +55,7 @@ uint16_t Scd30::measureAndWrite(MeasurementList& measurements,
     if (error) {
         return error;
     }
-    return HighLevelError::NoError;
+    return NoError;
 }
 
 uint16_t Scd30::initializationStep() {
@@ -105,11 +103,13 @@ unsigned long Scd30::getMinimumMeasurementIntervalMs() const {
 
 bool Scd30::probe() {
     uint8_t major, minor;
-    uint16_t error = mDriver.readFirmwareVersion(major, minor);
-    return (error == HighLevelError::NoError);
+    // stop potential running measurement
+    mDriver.stopPeriodicMeasurement();
+    const uint16_t error = mDriver.readFirmwareVersion(major, minor);
+    return (error == NoError);
 }
 
 void* Scd30::getDriver() {
-    return reinterpret_cast<void*>(&mDriver);
+    return &mDriver;
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Scd4x.cpp
+++ b/src/SensorWrappers/Scd4x.cpp
@@ -2,11 +2,10 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
-Scd4x::Scd4x(TwoWire& wire, const uint16_t address) : mWire(wire), 
-    mAddress{address},
-    mMetadata{core::SCD4X()}{};
+Scd4x::Scd4x(TwoWire& wire, const uint16_t address)
+    : mWire(wire), mAddress{address}, mMetadata{core::SCD4X()} {};
 
 uint16_t Scd4x::start() {
     mDriver.begin(mWire, mAddress);
@@ -18,22 +17,22 @@ uint16_t Scd4x::measureAndWrite(MeasurementList& measurements,
     uint16_t co2;
     float temp;
     float humi;
-    uint16_t error = mDriver.readMeasurement(co2, temp, humi);
+    const uint16_t error = mDriver.readMeasurement(co2, temp, humi);
     if (error) {
         return error;
     }
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::CO2_PARTS_PER_MILLION,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::CO2_PARTS_PER_MILLION,
         core::DataPoint{timeStamp, static_cast<float>(co2)});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
-        core::DataPoint{timeStamp, temp});        
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              core::DataPoint{timeStamp, temp});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
-        core::DataPoint{timeStamp, humi});      
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+                              core::DataPoint{timeStamp, humi});
 
     return HighLevelError::NoError;
 }
@@ -86,16 +85,19 @@ unsigned long Scd4x::getInitializationIntervalMs() const {
 }
 
 bool Scd4x::probe() {
+    // stop potential running measurement
+    mDriver.stopPeriodicMeasurement();
     SCD4xSensorVariant aSensorVariant = SCD4X_SENSOR_VARIANT_MASK;
-    uint16_t error = mDriver.getSensorVariant(aSensorVariant);
-    bool isKnownVariant = (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD40) ||
-                            (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD41) ||
-                            (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD42) ||
-                            (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD43);
+    const uint16_t error = mDriver.getSensorVariant(aSensorVariant);
+    const bool isKnownVariant =
+        (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD40) ||
+        (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD41) ||
+        (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD42) ||
+        (aSensorVariant == SCD4X_SENSOR_VARIANT_SCD43);
     return (error == 0 && isKnownVariant);
 }
 
 void* Scd4x::getDriver() {
-    return std::addressof(mDriver);
+    return &mDriver;
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Sen5x.cpp
+++ b/src/SensorWrappers/Sen5x.cpp
@@ -2,12 +2,10 @@
 #include "SensirionCore.h"
 #include <map>
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
-Sen5x::Sen5x(TwoWire& wire, uint16_t address) : 
-    mWire(wire),
-    mAddress{address},
-    mMetadata{core::SEN5X()} {};
+Sen5x::Sen5x(TwoWire& wire, uint16_t address)
+    : mWire(wire), mAddress{address}, mMetadata{core::SEN5X()} {};
 
 uint16_t Sen5x::start() {
     mDriver.begin(mWire);
@@ -37,48 +35,41 @@ uint16_t Sen5x::measureAndWrite(MeasurementList& measurements,
         return error;
     }
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::PM1P0_MICRO_GRAMM_PER_CUBIC_METER,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::PM1P0_MICRO_GRAMM_PER_CUBIC_METER,
         core::DataPoint{timeStamp, massConcentrationPm1p0});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::PM2P5_MICRO_GRAMM_PER_CUBIC_METER,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::PM2P5_MICRO_GRAMM_PER_CUBIC_METER,
         core::DataPoint{timeStamp, massConcentrationPm2p5});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::PM4P0_MICRO_GRAMM_PER_CUBIC_METER,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::PM4P0_MICRO_GRAMM_PER_CUBIC_METER,
         core::DataPoint{timeStamp, massConcentrationPm4p0});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::PM10P0_MICRO_GRAMM_PER_CUBIC_METER,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::PM10P0_MICRO_GRAMM_PER_CUBIC_METER,
         core::DataPoint{timeStamp, massConcentrationPm10p0});
 
+    // Versions 54, 55
+    if (getDeviceType() == core::SEN54() or getDeviceType() == core::SEN55()) {
 
-
-    // Verions 54, 55
-    if (getDeviceType() == core::SEN54() or
-        getDeviceType() == core::SEN55()) {
-
-        measurements.emplace_back(mMetadata, 
-            core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+        measurements.emplace_back(
+            mMetadata, core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
             core::DataPoint{timeStamp, ambientHumidity});
 
-        measurements.emplace_back(mMetadata, 
-            core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
+        measurements.emplace_back(
+            mMetadata, core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
             core::DataPoint{timeStamp, ambientTemperature});
 
-        measurements.emplace_back(mMetadata, 
-            core::SignalType::VOC_INDEX,
-            core::DataPoint{timeStamp, vocIndex});
-
+        measurements.emplace_back(mMetadata, core::SignalType::VOC_INDEX,
+                                  core::DataPoint{timeStamp, vocIndex});
     }
     // Version 55
     if (getDeviceType() == core::SEN55()) {
 
-        measurements.emplace_back(mMetadata, 
-            core::SignalType::NOX_INDEX,
-            core::DataPoint{timeStamp, noxIndex});
-
+        measurements.emplace_back(mMetadata, core::SignalType::NOX_INDEX,
+                                  core::DataPoint{timeStamp, noxIndex});
     }
     return HighLevelError::NoError;
 }
@@ -97,14 +88,14 @@ uint16_t Sen5x::initializationStep() {
     }
 
     // Get sensor unique ID (last 8 chars of serial no.)
-    uint8_t serialNumberSize = 32;
+    constexpr uint8_t serialNumberSize = 32;
     unsigned char serialNumber[serialNumberSize];
     error = mDriver.getSerialNumber(serialNumber, serialNumberSize);
     if (error) {
         return error;
     }
-    size_t actualLen = strlen((const char*)serialNumber);
-    size_t numBytesToCopy = min(8, (int)actualLen);
+    size_t actualLen = strlen(reinterpret_cast<const char*>(serialNumber));
+    size_t numBytesToCopy = min(8, static_cast<int>(actualLen));
     uint64_t sensorID = 0;
     for (int i = 0; i < numBytesToCopy - 1; i++) {
         sensorID |= (serialNumber[actualLen - numBytesToCopy - 1 + i]);
@@ -139,7 +130,7 @@ size_t Sen5x::getNumberOfDataPoints() const {
         {core::SEN55(), 8},
     };
     const auto iter = deviceToSignalCount.find(getDeviceType());
-    if (iter == deviceToSignalCount.cend()){
+    if (iter == deviceToSignalCount.cend()) {
         return 0;
     }
     return iter->second;
@@ -150,11 +141,14 @@ unsigned long Sen5x::getMinimumMeasurementIntervalMs() const {
 }
 
 bool Sen5x::probe() {
-    return _determineSensorVersion() == HighLevelError::NoError;
+    // reset the device before probing to ensure a clean state
+    mDriver.deviceReset();
+
+    return _determineSensorVersion() == NoError;
 }
 
 void* Sen5x::getDriver() {
-    return reinterpret_cast<void*>(&mDriver);
+    return &mDriver;
 }
 
 uint8_t Sen5x::getI2CAddress() const {
@@ -162,9 +156,10 @@ uint8_t Sen5x::getI2CAddress() const {
 };
 
 uint16_t Sen5x::_determineSensorVersion() {
-    uint8_t sensorNameSize = 32;
+    constexpr uint8_t sensorNameSize = 32;
     unsigned char sensorNameStr[sensorNameSize];
-    uint16_t error = mDriver.getProductName(sensorNameStr, sensorNameSize);
+    const uint16_t error =
+        mDriver.getProductName(sensorNameStr, sensorNameSize);
 
     if (error) {
         return error;
@@ -183,4 +178,4 @@ uint16_t Sen5x::_determineSensorVersion() {
     }
     return 0;
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Sen66.cpp
+++ b/src/SensorWrappers/Sen66.cpp
@@ -1,11 +1,10 @@
 #include "SensorWrappers/Sen66.h"
 #include "SensirionCore.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
-Sen66::Sen66(TwoWire& wire, uint16_t address) : mWire(wire), 
-    mAddress{address}, mMetaData{core::SEN66()} {
-};
+Sen66::Sen66(TwoWire& wire, uint16_t address)
+    : mWire(wire), mAddress{address}, mMetaData{core::SEN66()} {};
 
 uint16_t Sen66::start() {
     mDriver.begin(mWire, mAddress);
@@ -36,56 +35,44 @@ uint16_t Sen66::measureAndWrite(MeasurementList& measurements,
         return error;
     }
 
-    measurements.emplace_back(mMetaData,
-        core::SignalType::PM1P0_MICRO_GRAMM_PER_CUBIC_METER,
-        core::DataPoint{timeStamp, massConcentrationPm1p0}
-    );
+    measurements.emplace_back(
+        mMetaData, core::SignalType::PM1P0_MICRO_GRAMM_PER_CUBIC_METER,
+        core::DataPoint{timeStamp, massConcentrationPm1p0});
+
+    measurements.emplace_back(
+        mMetaData, core::SignalType::PM2P5_MICRO_GRAMM_PER_CUBIC_METER,
+        core::DataPoint{timeStamp, massConcentrationPm2p5});
+
+    measurements.emplace_back(
+        mMetaData, core::SignalType::PM4P0_MICRO_GRAMM_PER_CUBIC_METER,
+        core::DataPoint{timeStamp, massConcentrationPm4p0});
+
+    measurements.emplace_back(
+        mMetaData, core::SignalType::PM10P0_MICRO_GRAMM_PER_CUBIC_METER,
+        core::DataPoint{timeStamp, massConcentrationPm10p0});
 
     measurements.emplace_back(mMetaData,
-        core::SignalType::PM2P5_MICRO_GRAMM_PER_CUBIC_METER,
-        core::DataPoint{timeStamp, massConcentrationPm2p5}
-    );    
+                              core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+                              core::DataPoint{timeStamp, humidity});
 
     measurements.emplace_back(mMetaData,
-        core::SignalType::PM4P0_MICRO_GRAMM_PER_CUBIC_METER,
-        core::DataPoint{timeStamp, massConcentrationPm4p0}
-    );
+                              core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              core::DataPoint{timeStamp, temperature});
 
-    measurements.emplace_back(mMetaData,
-        core::SignalType::PM10P0_MICRO_GRAMM_PER_CUBIC_METER,
-        core::DataPoint{timeStamp, massConcentrationPm10p0}
-    );  
+    measurements.emplace_back(mMetaData, core::SignalType::VOC_INDEX,
+                              core::DataPoint{timeStamp, vocIndex});
 
-    measurements.emplace_back(mMetaData,
-        core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
-        core::DataPoint{timeStamp, humidity}
-    );
-
-    measurements.emplace_back(mMetaData,
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
-        core::DataPoint{timeStamp, temperature}
-    );      
-
-    measurements.emplace_back(mMetaData,
-        core::SignalType::VOC_INDEX,
-        core::DataPoint{timeStamp, vocIndex}
-    );   
-
-    measurements.emplace_back(mMetaData,
-        core::SignalType::NOX_INDEX,
-        core::DataPoint{timeStamp, noxIndex}
-    );   
-
+    measurements.emplace_back(mMetaData, core::SignalType::NOX_INDEX,
+                              core::DataPoint{timeStamp, noxIndex});
 
     // Filter out 0xFFFF CO2 value
     if (co2 == 65535) {
         co2 = 0;
     }
 
-    measurements.emplace_back(mMetaData,
-        core::SignalType::CO2_PARTS_PER_MILLION,
-        core::DataPoint{timeStamp, static_cast<float>(co2)}
-    );       
+    measurements.emplace_back(
+        mMetaData, core::SignalType::CO2_PARTS_PER_MILLION,
+        core::DataPoint{timeStamp, static_cast<float>(co2)});
 
     return HighLevelError::NoError;
 }
@@ -146,7 +133,10 @@ uint8_t Sen66::getI2CAddress() const {
 
 bool Sen66::probe() {
     std::basic_string<int8_t> sensorNameStr(32, '\0');
-    uint16_t error = mDriver.getProductName(sensorNameStr.data(), sensorNameStr.capacity());
+    // reset device before probing
+    mDriver.deviceReset();
+    const uint16_t error =
+        mDriver.getProductName(sensorNameStr.data(), sensorNameStr.capacity());
     return !error && sensorNameStr == reinterpret_cast<const int8_t*>("SEN66");
 }
 
@@ -157,4 +147,4 @@ void* Sen66::getDriver() {
 unsigned long Sen66::getInitializationIntervalMs() const {
     return 1200;
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Sfa3x.cpp
+++ b/src/SensorWrappers/Sfa3x.cpp
@@ -1,12 +1,12 @@
 #include "SensorWrappers/Sfa3x.h"
 #include "SensirionCore.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
 using namespace sensirion::upt::core;
 
-Sfa3x::Sfa3x(TwoWire& wire, uint16_t address) : mWire(wire), mAddress{address},
-    mMetadata{core::SFA3X()}{};
+Sfa3x::Sfa3x(TwoWire& wire, uint16_t address)
+    : mWire(wire), mAddress{address}, mMetadata{SFA3X()} {};
 
 uint16_t Sfa3x::start() {
     mDriver.begin(mWire, mAddress);
@@ -19,39 +19,39 @@ uint16_t Sfa3x::measureAndWrite(MeasurementList& measurements,
     float humi;
     float temperature;
 
-    uint16_t error = mDriver.readMeasuredValues(hcho, humi, temperature);
+    const uint16_t error = mDriver.readMeasuredValues(hcho, humi, temperature);
     if (error) {
         return error;
     }
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::HCHO_PARTS_PER_BILLION,
-        core::DataPoint{timeStamp, hcho});
+    measurements.emplace_back(mMetadata, SignalType::HCHO_PARTS_PER_BILLION,
+                              DataPoint{timeStamp, hcho});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
-        core::DataPoint{timeStamp, humi});    
+    measurements.emplace_back(mMetadata,
+                              SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+                              DataPoint{timeStamp, humi});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
-        core::DataPoint{timeStamp, temperature});
+    measurements.emplace_back(mMetadata,
+                              SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              DataPoint{timeStamp, temperature});
 
-    return HighLevelError::NoError;
+    return NoError;
 }
 
 uint16_t Sfa3x::initializationStep() {
-    uint16_t error = mDriver.stopMeasurement();
+    uint16_t error = mDriver.deviceReset();
     if (error) {
         return error;
     }
 
-    uint8_t serialNumberSize = 32;
+    constexpr uint8_t serialNumberSize = 32;
     int8_t serialNumber[serialNumberSize];
     error = mDriver.getDeviceMarking(serialNumber, serialNumberSize);
     if (error) {
         return error;
     }
-    size_t actualLen = strlen((const char*)serialNumber);
-    size_t numBytesToCopy = min(8, (int)actualLen);
+    const size_t actualLen =
+        strlen(reinterpret_cast<const char*>(serialNumber));
+    const size_t numBytesToCopy = min(8, static_cast<int>(actualLen));
 
     uint64_t sensorID = 0;
     for (int i = 0; i < numBytesToCopy - 1; i++) {
@@ -66,11 +66,11 @@ uint16_t Sfa3x::initializationStep() {
     return error;
 }
 
-core::DeviceType Sfa3x::getDeviceType() const {
+DeviceType Sfa3x::getDeviceType() const {
     return mMetadata.deviceType;
 }
 
-core::MetaData Sfa3x::getMetaData() const {
+MetaData Sfa3x::getMetaData() const {
     return mMetadata;
 }
 
@@ -82,20 +82,20 @@ uint8_t Sfa3x::getI2CAddress() const {
     return mAddress;
 };
 
-
 unsigned long Sfa3x::getMinimumMeasurementIntervalMs() const {
     return 5000;
 }
 
 bool Sfa3x::probe() {
-    uint8_t markingSize = 32;
+    constexpr uint8_t markingSize = 32;
     int8_t markingStr[markingSize];
-    uint16_t error = mDriver.getDeviceMarking(markingStr, markingSize);
-    return (error == HighLevelError::NoError);
+    // reset device before probing
+    mDriver.deviceReset();
+    const uint16_t error = mDriver.getDeviceMarking(markingStr, markingSize);
+    return (error == NoError);
 }
 
 void* Sfa3x::getDriver() {
-    return reinterpret_cast<void*>(&mDriver);
+    return &mDriver;
 }
-} // namespace sensirion::upt::i2c_autodetect 
-
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Sgp4x.cpp
+++ b/src/SensorWrappers/Sgp4x.cpp
@@ -86,10 +86,10 @@ uint8_t Sgp41::getI2CAddress() const {
 };
 
 bool Sgp41::probe() {
-    // Use getSerialNumber as probe method
+    // Use getSerialNumber as a probe method
     uint16_t serialNo[3];
-    uint16_t error = mDriver.getSerialNumber(serialNo);
-    return (error == HighLevelError::NoError);  
+    const uint16_t error = mDriver.getSerialNumber(serialNo);
+    return (error == NoError);
 }
 
 } // namespace sensirion::upt::i2c_autodetect 

--- a/src/SensorWrappers/Sht4x.cpp
+++ b/src/SensorWrappers/Sht4x.cpp
@@ -2,36 +2,36 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
 using namespace sensirion::upt::core;
 
-Sht4x::Sht4x(TwoWire& wire, uint16_t address) : mWire(wire), mAddress{address},
-    mMetadata{core::SHT4X()}{};
+Sht4x::Sht4x(TwoWire& wire, uint16_t address)
+    : mWire(wire), mAddress{address}, mMetadata{SHT4X()} {};
 
 uint16_t Sht4x::start() {
     mDriver.begin(mWire, mAddress);
-    return HighLevelError::NoError;
+    return NoError;
 }
 
 uint16_t Sht4x::measureAndWrite(MeasurementList& measurements,
                                 const unsigned long timeStamp) {
     float temperature;
     float humi;
-    uint16_t error = mDriver.measureHighPrecision(temperature, humi);
+    const uint16_t error = mDriver.measureHighPrecision(temperature, humi);
     if (error) {
         return error;
     }
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
-        core::DataPoint{timeStamp, temperature});
+    measurements.emplace_back(mMetadata,
+                              SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              DataPoint{timeStamp, temperature});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
-        core::DataPoint{timeStamp, humi});
+    measurements.emplace_back(mMetadata,
+                              SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+                              DataPoint{timeStamp, humi});
 
-    return HighLevelError::NoError;
+    return NoError;
 }
 
 uint16_t Sht4x::initializationStep() {
@@ -61,7 +61,7 @@ unsigned long Sht4x::getMinimumMeasurementIntervalMs() const {
 }
 
 void* Sht4x::getDriver() {
-    return reinterpret_cast<void*>(&mDriver);
+    return &mDriver;
 }
 
 uint8_t Sht4x::getI2CAddress() const {
@@ -71,7 +71,7 @@ uint8_t Sht4x::getI2CAddress() const {
 bool Sht4x::probe() {
     // Use serial number as a probe method
     uint32_t serial;
-    uint16_t error = mDriver.serialNumber(serial);
-    return (error == HighLevelError::NoError);
+    const uint16_t error = mDriver.serialNumber(serial);
+    return (error == NoError);
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Stc3x.cpp
+++ b/src/SensorWrappers/Stc3x.cpp
@@ -2,16 +2,17 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
-Stc3x::Stc3x(TwoWire& wire, uint16_t address) : mWire(wire), mAddress{address},
-    mMetadata{core::STC3X()}
- {// The device type is determined more precisely at initializationStep()
- };
+Stc3x::Stc3x(TwoWire& wire, uint16_t address)
+    : mWire(wire), mAddress{address},
+      mMetadata{core::STC3X()} {  // The device type is determined more
+                                  // precisely at initializationStep()
+      };
 
 uint16_t Stc3x::start() {
     mDriver.begin(mWire, mAddress);
-    uint16_t error = mDriver.setBinaryGas(0x0001);
+    const uint16_t error = mDriver.setBinaryGas(0x0001);
     return error;
 }
 
@@ -20,19 +21,19 @@ uint16_t Stc3x::measureAndWrite(MeasurementList& measurements,
     float gasValue;
     float temperatureValue;
 
-    uint16_t error =
+    const uint16_t error =
         mDriver.measureGasConcentration(gasValue, temperatureValue);
     if (error) {
         return error;
     }
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::GAS_CONCENTRATION_VOLUME_PERCENTAGE,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::GAS_CONCENTRATION_VOLUME_PERCENTAGE,
         core::DataPoint{timeStamp, gasValue});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
-        core::DataPoint{timeStamp, temperatureValue});
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              core::DataPoint{timeStamp, temperatureValue});
 
     return HighLevelError::NoError;
 }
@@ -59,18 +60,18 @@ uint16_t Stc3x::initializationStep() {
      * https://sensirion.com/media/documents/7B1D0EA7/61652CD0/Sensirion_Thermal_Conductivity_Datasheet_STC31_D1_1.pdf
      * Section 3.3.13
      */
-    const uint32_t stc31ProductNumber = 0x08010301;
-    const uint32_t mask = 0xFFFFFF00;
+    constexpr uint32_t stc31ProductNumber = 0x08010301;
+    constexpr uint32_t mask = 0xFFFFFF00;
     const uint32_t maskedProductNo = productNumber & mask;
-    const uint32_t maskedSTC31ProductNo = stc31ProductNumber & mask;
+    constexpr uint32_t maskedSTC31ProductNo = stc31ProductNumber & mask;
     if (maskedSTC31ProductNo == maskedProductNo) {
         mMetadata.deviceType = core::STC31();
     }  // else keep default STC3X
 
     // Sensor Serial No
     uint64_t sensorID = 0;
-    sensorID |=
-        (uint64_t)serialNumberRawHigh << 32 | (uint64_t)serialNumberRawLow;
+    sensorID |= static_cast<uint64_t>(serialNumberRawHigh) << 32 |
+                static_cast<uint64_t>(serialNumberRawLow);
     mMetadata.deviceID = sensorID;
 
     // Select gas mode
@@ -104,7 +105,7 @@ uint16_t Stc3x::initializationStep() {
         return error;
     }
 
-    return HighLevelError::NoError;
+    return NoError;
 }
 
 core::DeviceType Stc3x::getDeviceType() const {
@@ -130,11 +131,11 @@ unsigned long Stc3x::getMinimumMeasurementIntervalMs() const {
 bool Stc3x::probe() {
     uint32_t productId;
     uint64_t serialNumber;
-    int16_t error = mDriver.getProductId(productId, serialNumber);
-    return (error == HighLevelError::NoError && productId == 0x08010304);
+    const int16_t error = mDriver.getProductId(productId, serialNumber);
+    return (error == NoError && productId == 0x08010304);
 }
 
 void* Stc3x::getDriver() {
-    return reinterpret_cast<void*>(&mDriver);
+    return &mDriver;
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect

--- a/src/SensorWrappers/Stcc4.cpp
+++ b/src/SensorWrappers/Stcc4.cpp
@@ -2,11 +2,10 @@
 #include "SensirionCore.h"
 #include "Sensirion_UPT_Core.h"
 
-namespace sensirion::upt::i2c_autodetect{
+namespace sensirion::upt::i2c_autodetect {
 
-Stcc4::Stcc4(TwoWire& wire, uint16_t address) : mWire(wire), 
-    mAddress{address}, mMetadata{core::STCC4()} {
-};
+Stcc4::Stcc4(TwoWire& wire, uint16_t address)
+    : mWire(wire), mAddress{address}, mMetadata{core::STCC4()} {};
 
 uint16_t Stcc4::start() {
     mDriver.begin(mWire, mAddress);
@@ -18,28 +17,28 @@ uint16_t Stcc4::measureAndWrite(MeasurementList& measurements,
     int16_t co2;
     float temperatureValue;
     float relativeHumidityValue;
-    uint16_t sensorStatus; // Required by API but not used in this implementation
+    uint16_t
+        sensorStatus;  // Required by API but not used in this implementation
 
-    uint16_t error =
-        mDriver.readMeasurement(co2, temperatureValue, relativeHumidityValue, sensorStatus);
+    const uint16_t error = mDriver.readMeasurement(
+        co2, temperatureValue, relativeHumidityValue, sensorStatus);
     if (error) {
         return error;
     }
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::CO2_PARTS_PER_MILLION,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::CO2_PARTS_PER_MILLION,
         core::DataPoint{timeStamp, static_cast<float>(co2)});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
-        core::DataPoint{timeStamp, temperatureValue});
+    measurements.emplace_back(mMetadata,
+                              core::SignalType::TEMPERATURE_DEGREES_CELSIUS,
+                              core::DataPoint{timeStamp, temperatureValue});
 
-    measurements.emplace_back(mMetadata, 
-        core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
+    measurements.emplace_back(
+        mMetadata, core::SignalType::RELATIVE_HUMIDITY_PERCENTAGE,
         core::DataPoint{timeStamp, relativeHumidityValue});
 
-
-    return HighLevelError::NoError;
+    return NoError;
 }
 
 uint16_t Stcc4::initializationStep() {
@@ -85,11 +84,13 @@ unsigned long Stcc4::getMinimumMeasurementIntervalMs() const {
 bool Stcc4::probe() {
     uint32_t productId;
     uint64_t serialNumber;
-    int16_t error = mDriver.getProductId(productId, serialNumber);
-    return (error == HighLevelError::NoError && productId == 0x0901018A);
+    // stop a potential running measurement
+    mDriver.stopContinuousMeasurement();
+    const int16_t error = mDriver.getProductId(productId, serialNumber);
+    return (error == NoError && productId == 0x0901018A);
 }
 
 void* Stcc4::getDriver() {
-    return reinterpret_cast<void*>(&mDriver);
+    return &mDriver;
 }
-} // namespace sensirion::upt::i2c_autodetect 
+}  // namespace sensirion::upt::i2c_autodetect


### PR DESCRIPTION
Probing failed for certain sensors if a e.g. a measurement was running. This commit ensures that measurements are stopped or the device is reset before probing if necessary.

Fix several clang tidy issues.

Prepare for 3.0.1 bugfix release