### PR TITLE
Update SEN6x probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1]
+
+### Changed
+- Update all SEN6x driver dependencies to the latest release
+
+### Fixed
+- Use product type for probing instead of sensor name, since sensor name is not
+  always consistent and causes probing to fail on some samples.
+
 ## [3.1.0]
 
 ### Added

--- a/examples/basicUsage/basicUsage.ino
+++ b/examples/basicUsage/basicUsage.ino
@@ -27,9 +27,9 @@ void setup() {
     
     Serial.begin(115200);
 
-    int sda_pin = 21;  // Default on esp32 boards
-    int scl_pin = 22;
-    Wire.begin(sda_pin, scl_pin);
+    constexpr int sdaPin = 21;  // Default on esp32 boards
+    constexpr int sclPin = 22;
+    Wire.begin(sdaPin, sclPin);
 
     maxNumSensors = DefaultI2cDetector::CONFIGURED_SENSORS;
     pCurrentData = new const ISensor::MeasurementList* [maxNumSensors] { nullptr };

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sensirion UPT I2C Auto Detection
-version=3.1.0
+version=3.1.1
 author=Jonas Stolle, Maximilian Paulsen
 maintainer=Sensirion AG <sensirion.com>
 sentence=Automatically detects Sensirion Sensors on an I2C bus and reads out measurement data.

--- a/platformio.ini
+++ b/platformio.ini
@@ -23,12 +23,12 @@ lib_deps_external =
     Sensirion/Sensirion I2C SCD30@1.0.0
     Sensirion/Sensirion I2C SGP41@1.0.0
     Sensirion/Sensirion I2C STC3x@1.0.1
-    Sensirion/Sensirion I2C SEN62@1.0.0
-    Sensirion/Sensirion I2C SEN63C@1.0.1
-    Sensirion/Sensirion I2C SEN65@1.0.1
-    Sensirion/Sensirion I2C SEN66@1.2.0
-    Sensirion/Sensirion I2C SEN68@1.0.1
-    Sensirion/Sensirion I2C SEN69C@1.0.0
+    Sensirion/Sensirion I2C SEN62@1.1.0
+    Sensirion/Sensirion I2C SEN63C@1.1.0
+    Sensirion/Sensirion I2C SEN65@1.1.0
+    Sensirion/Sensirion I2C SEN66@1.3.1
+    Sensirion/Sensirion I2C SEN68@1.1.0
+    Sensirion/Sensirion I2C SEN69C@1.1.0
     Sensirion/Sensirion I2C STCC4@1.0.0
 basicUsage_srcdir = ${PROJECT_DIR}/examples/basicUsage/
 advancedUsage_srcdir = ${PROJECT_DIR}/examples/advancedUsage/

--- a/src/SensorWrappers/Sen62.cpp
+++ b/src/SensorWrappers/Sen62.cpp
@@ -101,14 +101,14 @@ uint8_t Sen62::getI2CAddress() const {
 };
 
 bool Sen62::probe() {
-    constexpr uint8_t sensorNameSize = 32;
-    int8_t sensorName[sensorNameSize] = {0};
+    constexpr uint8_t productTypeSize = 32;
+    int8_t productType[productTypeSize] = {0};
     // reset device before probing
     mDriver.deviceReset();
-    const uint16_t error = mDriver.getProductName(sensorName, sensorNameSize);
-    return !error &&
-           strncmp(reinterpret_cast<const char*>(sensorName), "SEN62",
-                   sensorNameSize) == 0;
+    const uint16_t error = mDriver.getProductType(productType, productTypeSize);
+    uint32_t productTypeNum =
+        strtoul(reinterpret_cast<const char*>(productType), nullptr, 16);
+    return !error && productTypeNum == 0x00085800;
 }
 
 void* Sen62::getDriver() {

--- a/src/SensorWrappers/Sen63c.cpp
+++ b/src/SensorWrappers/Sen63c.cpp
@@ -22,7 +22,7 @@ uint16_t Sen63c::measureAndWrite(MeasurementList& measurements,
     float massConcentrationPm10p0 = 0.0;
     float humidity = 0.0;
     float temperature = 0.0;
-    uint16_t co2 = 0.0;
+    int16_t co2 = 0.0;
 
     error = mDriver.readMeasuredValues(
         massConcentrationPm1p0, massConcentrationPm2p5, massConcentrationPm4p0,
@@ -111,14 +111,14 @@ uint8_t Sen63c::getI2CAddress() const {
 };
 
 bool Sen63c::probe() {
-    constexpr uint8_t sensorNameSize = 32;
-    int8_t sensorName[sensorNameSize] = {0};
+    constexpr uint8_t productTypeSize = 32;
+    int8_t productType[productTypeSize] = {0};
     // reset device before probing
     mDriver.deviceReset();
-    const uint16_t error = mDriver.getProductName(sensorName, sensorNameSize);
-    return !error &&
-           strncmp(reinterpret_cast<const char*>(sensorName), "SEN63C",
-                   sensorNameSize) == 0;
+    const uint16_t error = mDriver.getProductType(productType, productTypeSize);
+    uint32_t productTypeNum =
+        strtoul(reinterpret_cast<const char*>(productType), nullptr, 16);
+    return !error && productTypeNum == 0x00085700;
 }
 
 void* Sen63c::getDriver() {

--- a/src/SensorWrappers/Sen65.cpp
+++ b/src/SensorWrappers/Sen65.cpp
@@ -110,14 +110,14 @@ uint8_t Sen65::getI2CAddress() const {
 };
 
 bool Sen65::probe() {
-    constexpr uint8_t sensorNameSize = 32;
-    int8_t sensorName[sensorNameSize] = {0};
+    constexpr uint8_t productTypeSize = 32;
+    int8_t productType[productTypeSize] = {0};
     // reset device before probing
     mDriver.deviceReset();
-    const uint16_t error = mDriver.getProductName(sensorName, sensorNameSize);
-    return !error &&
-           strncmp(reinterpret_cast<const char*>(sensorName), "SEN65",
-                   sensorNameSize) == 0;
+    const uint16_t error = mDriver.getProductType(productType, productTypeSize);
+    uint32_t productTypeNum =
+        strtoul(reinterpret_cast<const char*>(productType), nullptr, 16);
+    return !error && productTypeNum == 0x00085200;
 }
 
 void* Sen65::getDriver() {

--- a/src/SensorWrappers/Sen66.cpp
+++ b/src/SensorWrappers/Sen66.cpp
@@ -120,14 +120,14 @@ uint8_t Sen66::getI2CAddress() const {
 };
 
 bool Sen66::probe() {
-    constexpr uint8_t sensorNameSize = 32;
-    int8_t sensorName[sensorNameSize] = {0};
+    constexpr uint8_t productTypeSize = 32;
+    int8_t productType[productTypeSize] = {0};
     // reset device before probing
     mDriver.deviceReset();
-    const uint16_t error = mDriver.getProductName(sensorName, sensorNameSize);
-    return !error &&
-           strncmp(reinterpret_cast<const char*>(sensorName), "SEN66",
-                   sensorNameSize) == 0;
+    const uint16_t error = mDriver.getProductType(productType, productTypeSize);
+    uint32_t productTypeNum =
+        strtoul(reinterpret_cast<const char*>(productType), nullptr, 16);
+    return !error && productTypeNum == 0x00085300;
 }
 
 void* Sen66::getDriver() {

--- a/src/SensorWrappers/Sen68.cpp
+++ b/src/SensorWrappers/Sen68.cpp
@@ -116,14 +116,14 @@ uint8_t Sen68::getI2CAddress() const {
 };
 
 bool Sen68::probe() {
-    constexpr uint8_t sensorNameSize = 32;
-    int8_t sensorName[sensorNameSize] = {0};
+    constexpr uint8_t productTypeSize = 32;
+    int8_t productType[productTypeSize] = {0};
     // reset device before probing
     mDriver.deviceReset();
-    const uint16_t error = mDriver.getProductName(sensorName, sensorNameSize);
-    return !error &&
-           strncmp(reinterpret_cast<const char*>(sensorName), "SEN68",
-                   sensorNameSize) == 0;
+    const uint16_t error = mDriver.getProductType(productType, productTypeSize);
+    uint32_t productTypeNum =
+        strtoul(reinterpret_cast<const char*>(productType), nullptr, 16);
+    return !error && productTypeNum == 0x00085400;
 }
 
 void* Sen68::getDriver() {

--- a/src/SensorWrappers/Sen69c.cpp
+++ b/src/SensorWrappers/Sen69c.cpp
@@ -120,14 +120,14 @@ uint8_t Sen69c::getI2CAddress() const {
 };
 
 bool Sen69c::probe() {
-    constexpr uint8_t sensorNameSize = 32;
-    int8_t sensorName[sensorNameSize] = {0};
+    constexpr uint8_t productTypeSize = 32;
+    int8_t productType[productTypeSize] = {0};
     // reset device before probing
     mDriver.deviceReset();
-    const uint16_t error = mDriver.getProductName(sensorName, sensorNameSize);
-    return !error &&
-           strncmp(reinterpret_cast<const char*>(sensorName), "SEN69C",
-                   sensorNameSize) == 0;
+    const uint16_t error = mDriver.getProductType(productType, productTypeSize);
+    uint32_t productTypeNum =
+        strtoul(reinterpret_cast<const char*>(productType), nullptr, 16);
+    return !error && productTypeNum == 0x00085900;
 }
 
 void* Sen69c::getDriver() {


### PR DESCRIPTION
Update dependencies for all SEN6x drivers and use new getProductType API to check for the attached sensor as it is more reliable than the sensor name string.